### PR TITLE
Refactor request_parser's interface to break ties with tcp socket

### DIFF
--- a/examples/basic_server/handler.hpp
+++ b/examples/basic_server/handler.hpp
@@ -10,7 +10,7 @@ class handler {
   public:
     handler() {}
 
-    void operator()(server::request_parser& request, server::socket_writer& writer) {
+    void operator()(server::request& request, server::socket_writer& writer) {
         server::main_logger.info("Handling request: " + std::string(request));
         std::map<std::string, std::string> params = request.query_params();
         for (std::map<std::string, std::string>::const_iterator it = params.cbegin();

--- a/include/server/router.hpp
+++ b/include/server/router.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "logger.hpp"
-#include "request_parser.hpp"
+#include "request.hpp"
 #include "route.hpp"
 #include "writer.hpp"
 #include <boost/beast/http.hpp>
@@ -15,7 +15,7 @@ namespace server {
     template <class Stream> class basic_router {
 
       public:
-        using handler_type = std::function<void(request_parser&, basic_writer<Stream>&)>;
+        using handler_type = std::function<void(request&, basic_writer<Stream>&)>;
         using element_type = std::pair<route, handler_type>;
         using container_type = std::vector<element_type>;
         using iterator_type = typename container_type::iterator;

--- a/include/server/server.hpp
+++ b/include/server/server.hpp
@@ -4,7 +4,7 @@
 #include "http_server.hpp"
 #include "logger.hpp"
 #include "path.hpp"
-#include "request_parser.hpp"
+#include "request.hpp"
 #include "response_builder.hpp"
 #include "route.hpp"
 #include "router.hpp"


### PR DESCRIPTION
This pull request turns request_parser into request, which is a representation of a parsed request.
Previously, http_server had to pass in an http socket reference so that request_parser can read
data from it in order to parse, which made request_parser difficult to test in isolation.

Closes: #10 